### PR TITLE
Fix passing form props to nested children. Add `isFormField` option.

### DIFF
--- a/components/form/README.md
+++ b/components/form/README.md
@@ -21,6 +21,9 @@ const Login = () => {
     action: 'auth/login',
     method: 'post',
     noAuth: true,
+    initialData: {
+      username: 'example'
+    },
     onSuccess: ({ token, userId }) => {
       setState(
         { token, userId }
@@ -42,10 +45,12 @@ const Login = () => {
       //   {
       //     LoginForm: {
       //       email: '',
+      //       username: '',
       //       password: ''
       //     }
       //   }
       <TextInput name='email' />
+      <input isFormField name='username' />
       <TextInput name='password' />
       <button type='submit'>Login</button>
     </Form>
@@ -75,6 +80,18 @@ let formFieldNames = [
 ```
 
 You can also add additional field names:
+
+```javacript
+import { addFieldNames } from '@app-elements/form'
+
+addFieldNames('MyCoolField', 'NeatoField', 'BurritoField')
+```
+
+Or add `isFormField` attribute:
+
+```javacript
+const MyCustomInput => <input isFormField name='hello' />
+```
 
 ```javacript
 import { addFieldNames } from '@app-elements/form'

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -46,12 +46,12 @@ const getNodeName = child =>
 
 const getProps = child => child.attributes || child.props || {}
 
-// Is one of the above defined form fields, and has a `name`
-// prop set. We can't sync state if the component doesn't have
+// Is one of the above defined form fields, (or has attribute isFormField)
+// and has a `name` prop set. We can't sync state if the component doesn't have
 // have a `name` prop set.
 const isFormField = child => {
   const name = getNodeName(child)
-  if (!formFieldNames.includes(name)) {
+  if (!formFieldNames.includes(name) && !(child.attributes && child.attributes.isFormField)) {
     return false
   } else if (getProps(child).name) {
     return true
@@ -97,6 +97,7 @@ export default class Form extends React.Component {
             [childProps.name]: state.value || state.text
           } })
         }
+
         if (!isReactNative) {
           newProps.onChange = ev => this.setState({ values: {
             ...this.state.values,
@@ -108,13 +109,11 @@ export default class Form extends React.Component {
         this._fields[childProps.name] = child
       } else if (child.children || childProps.children) {
         // Recursively search children for more form fields
-        child = React.cloneElement(child, {
-          formName,
-          children: this._updateChildFormFields(
-            child.children || childProps.children,
-            formName
-          )
-        })
+        child = React.cloneElement(
+          child,
+          { formName },
+          this._updateChildFormFields(child.children || childProps.children, formName)
+        )
       }
 
       return child

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -51,9 +51,10 @@ const getProps = child => child.attributes || child.props || {}
 // have a `name` prop set.
 const isFormField = child => {
   const name = getNodeName(child)
-  if (!formFieldNames.includes(name) && !(child.attributes && child.attributes.isFormField)) {
+  const props = getProps(child)
+  if (!formFieldNames.includes(name) && !props.isFormField) {
     return false
-  } else if (getProps(child).name) {
+  } else if (props.name) {
     return true
   } else {
     console.warn(`Found Component '${name}' missing 'name' prop!`)


### PR DESCRIPTION
fixes #40 and adds option for any child of form to accept form props with attribute `isFormField`.