### PR TITLE
useForm should not filter errors from API calls.

### DIFF
--- a/components/use-form/index.js
+++ b/components/use-form/index.js
@@ -67,7 +67,8 @@ export const useForm = ({
       }
     }
     if (hasProp.call(errorsRef.current || {}, fieldName)) {
-      fieldProps[hintProp] = errorsRef.current[fieldName]
+      const fieldErr = errorsRef.current[fieldName]
+      fieldProps[hintProp] = Array.isArray(fieldErr) ? fieldErr.join(' ') : fieldErr
       fieldProps.className = errorClass
     }
     return fieldProps
@@ -127,10 +128,7 @@ export const useForm = ({
         const handleErrRes = body => body
           .then(errors => {
             dataRef.current = {}
-            errorsRef.current = Array.from(fieldNames).reduce((acc, field) => ({
-              ...acc,
-              ...(hasProp.call(errors, field) ? { [field]: errors[field].join(' ') } : {})
-            }), {})
+            errorsRef.current = Object.assign({}, errors)
             setFormState(FAILURE)
           })
           .catch(err => console.error('handleErrRes', err))


### PR DESCRIPTION
Instead, the field method is udpated to render the error if it's found
on the errors object.

Closes #137